### PR TITLE
Add var.disable_implicit_clears()

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,18 @@ Function VOID clear()
 
 clear() clears the whole non-global variable space.
 
+VARNISH 4.0 LIMITATIONS:
+    - This VMOD is currently NOT available in the following Varnish 4.0 VCL
+    methods: vcl_backend_fetch, vcl_backend_response and vcl_backend_error.
+    For explanation and workaround see github issue #5.
 
-VARNISH 4.0 LIMITATION: This VMOD is currently NOT available in the
-following Varnish 4.0 VCL methods: vcl_backend_fetch,
-vcl_backend_response and vcl_backend_error. For explanation and workaround see github issue #5
+    - Local variables set using this VMOD will be reset when crossing a request
+    boundary, but also when restarting a request. This is the default behavior
+    in Varnish 4.0. Function disable_implicit_clears() is provided in order
+    disable implicit clears of the var space. This allows mimicking in Varnish
+    4.0 the default behavior in older and newer versions of Varnish (i.e.
+    cleaning the var space when crossing a request boundary but not during
+    restarts). When enabling this the var space must be manually cleared in VCL
+    (i.e. var.clear()) during the initial request (i.e. vcl_recv when
+    req.restart == 0) before doing any get or set operation. Otherwise crashes
+    are expected. For additional details see github issue #12.

--- a/README
+++ b/README
@@ -47,5 +47,5 @@ VARNISH 4.0 LIMITATIONS:
     cleaning the var space when crossing a request boundary but not during
     restarts). When enabling this the var space must be manually cleared in VCL
     (i.e. var.clear()) during the initial request (i.e. vcl_recv when
-    req.restart == 0) before doing any get or set operation. Otherwise crashes
+    req.restarts == 0) before doing any get or set operation. Otherwise crashes
     are expected. For additional details see github issue #12.

--- a/src/tests/test05.vtc
+++ b/src/tests/test05.vtc
@@ -1,0 +1,40 @@
+varnishtest "Test disable_implicit_clears() workaround"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+    import var from "${vmod_topbuild}/src/.libs/libvmod_var.so";
+
+    sub vcl_init {
+        var.disable_implicit_clears();
+    }
+
+    sub vcl_recv {
+        if (req.restarts == 0) {
+            var.clear();
+            var.set("foo", req.http.value);
+        }
+    }
+
+    sub vcl_deliver {
+        if (req.restarts == 0) {
+            return (restart);
+        }
+        set resp.http.x-foo = var.get("foo");
+    }
+} -start
+
+client c1 {
+    txreq -url "/" -hdr "value: bar"
+    rxresp
+    expect resp.http.x-foo == "bar"
+
+    txreq -url "/" -hdr "value: baz"
+    rxresp
+    expect resp.http.x-foo == "baz"
+}
+
+client c1 -run

--- a/src/vmod_var.vcc
+++ b/src/vmod_var.vcc
@@ -18,3 +18,5 @@ $Function DURATION get_duration(STRING)
 $Function VOID set_ip(STRING, IP)
 $Function IP get_ip(STRING)
 $Function VOID clear()
+
+$Function VOID disable_implicit_clears()


### PR DESCRIPTION
Allows mimicking in Varnish 4.0 behavior in older and newer versions: reset the var space when crossing a request boundary but not when restarting a request. It depends on some VCL (`var.clear()` during `vcl_recv` when `req.restarts == 0`) in order to avoid crashes. See GitHub issue #12 for details.
